### PR TITLE
Multi-tenancy support

### DIFF
--- a/azure_ad_client.js
+++ b/azure_ad_client.js
@@ -22,7 +22,7 @@ AzureAd.requestCredential = function (options, credentialRequestCompleteCallback
     var loginStyle = OAuth._loginStyle('azureAd', config, options);
     var credentialToken = Random.secret();
 
-    var baseUrl = "https://login.windows.net/" + config.tennantId + "/oauth2/authorize?";
+    var baseUrl = "https://login.windows.net/common/oauth2/authorize?";
     var loginUrl = baseUrl +
         'api-version=1.0&' +
         '&response_type=code' +

--- a/azure_ad_client.js
+++ b/azure_ad_client.js
@@ -19,6 +19,14 @@ AzureAd.requestCredential = function (options, credentialRequestCompleteCallback
         return;
     }
 
+    var prompt = '&prompt=login';
+    if (typeof options.loginPrompt === 'string') {
+        if (options.loginPrompt === "")
+            prompt = '';
+        else
+            prompt = '&prompt=' + options.loginPrompt;
+    }
+
     var loginStyle = OAuth._loginStyle('azureAd', config, options);
     var credentialToken = Random.secret();
 
@@ -26,7 +34,7 @@ AzureAd.requestCredential = function (options, credentialRequestCompleteCallback
     var loginUrl = baseUrl +
         'api-version=1.0&' +
         '&response_type=code' +
-        '&prompt=login' +
+        prompt +
         '&client_id=' + config.clientId +
         '&state=' + OAuth._stateParam(loginStyle, credentialToken) +
         '&redirect_uri=' + OAuth._redirectUri('azureAd', config);

--- a/lib/serverHttp.js
+++ b/lib/serverHttp.js
@@ -43,7 +43,7 @@ AzureAd.http.getAccessTokensBase = function (resourceUri, additionalRequestParam
 
     var config = AzureAd.getConfiguration();
 
-    var url = "https://login.windows.net/" + config.tennantId + "/oauth2/token/";
+    var url = "https://login.windows.net/common/oauth2/token/";
     var baseParams = {
         client_id: config.clientId,
         client_secret : OAuth.openSecret(config.secret),

--- a/resources/graph.js
+++ b/resources/graph.js
@@ -4,7 +4,7 @@ AzureAd.resources.graph.resourceUri = "https://graph.windows.net/";
 
 AzureAd.resources.graph.getUser = function (accessToken) {
     var config = AzureAd.getConfiguration();
-    var url = "https://graph.windows.net/" + config.tennantId + "/me?api-version=2013-11-08";
+    var url = "https://graph.windows.net/myorganization/me?api-version=2013-11-08";
 
     return AzureAd.http.callAuthenticated("GET", url, accessToken);
 };


### PR DESCRIPTION
Hi James!

I made a few modifications I'd be happy to discuss with you.

I managed to authenticate a user outside of our tenancy, that was hard because the info was buried deep into Microsoft's terrible doc, but the changes to make it work are ridiculous, I let you see by yourself.

So, with a properly configured app in the AzureAD portal, the changes allow to authenticate users from in and outside the tenancy.

Now I'm wondering if an app that's not configured for multi-tenancy would work with those changes, I haven't tested yet (I'm just thinking about it). If not I guess that can be done by passing an argument to the client-side function.

Tell me what you think, but before, have a nice weekend!

Quentin
